### PR TITLE
4 interface for symbol

### DIFF
--- a/Nt.Parser.Application/Programs/TextParsing.cs
+++ b/Nt.Parser.Application/Programs/TextParsing.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using Nt.Parser.Symbols;
+using System.Text;
 
 namespace Nt.Parser.Application.Programs
 {
@@ -33,7 +34,7 @@ namespace Nt.Parser.Application.Programs
                     var textToParse = text.ToString();
 
                     var config = ParserConfig.GetConfig();
-                    var parser = new SymbolsParser([' ', '\n'], config.SymbolsList);
+                    var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [' ', '\n'], config.SymbolsList);
                     var result = parser.Parse(textToParse);
 
                     Console.WriteLine("Parsing result:");

--- a/Nt.Parser.Domain/IParser.cs
+++ b/Nt.Parser.Domain/IParser.cs
@@ -1,7 +1,9 @@
-﻿namespace Nt.Parser
+﻿using Nt.Parser.Symbols;
+
+namespace Nt.Parser
 {
-    public interface IParser
+    public interface IParser<T> where T : ISymbol
     {
-        ParserResult Parse(string content);
+        ParserResult<T> Parse(string content);
     }
 }

--- a/Nt.Parser.Domain/Nt.Parser.Domain.csproj
+++ b/Nt.Parser.Domain/Nt.Parser.Domain.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 	<RootNamespace>Nt.Parser</RootNamespace>
 	<Title>Nt.Parser</Title>
-	<Description>Parametrisable text parser</Description>
+	<Description>Parser that can be customized</Description>
 	<Authors>Natvs</Authors>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
 	<RepositoryUrl>https://github.com/Natvs/Nt.Parser</RepositoryUrl>
@@ -15,6 +15,7 @@
 	<PackageTags>parser ; parsing ; token ; tokenisation ; tokenization</PackageTags>
 	<Version>1.0.0</Version>
 	<PackageId>Nt.Parser</PackageId>
+	<PackageReleaseNotes>First official release</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nt.Parser.Domain/ParserResult.cs
+++ b/Nt.Parser.Domain/ParserResult.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Parser.Structures;
+using Nt.Parser.Symbols;
 using System.Text;
 
 namespace Nt.Parser
@@ -6,17 +7,17 @@ namespace Nt.Parser
     /// <summary>
     /// Contains results of a successive parsing. 
     /// </summary>
-    public class ParserResult
+    public class ParserResult<T>(ISymbolFactory<T> factory) where T : ISymbol
     {
         /// <summary>
         /// List of unique symbols that the parser read. These words are referenced by parsed tokens.
         /// </summary>
-        internal SymbolsList Symbols { get; } = new();
+        internal SymbolsList<T> Symbols { get; } = new(factory);
 
         /// <summary>
         /// List of tokens that have been parsed. Value of a parsed token refers to the index in tokens list.
         /// </summary>
-        internal ParsedList Parsed { get; } = new();
+        internal ParsedList<T> Parsed { get; } = new();
 
         /// <summary>
         /// Retrieves a list of symbol names available in the current context.
@@ -37,14 +38,9 @@ namespace Nt.Parser
         /// Returns a list of symbol names corresponding to the parsed tokens.
         /// </summary>
         /// <returns>A list of strings containing the names of symbols for each token in the parsed sequence.</returns>
-        public List<string> GetParsed()
+        public List<ParsedToken<T>> GetParsed()
         {
-            var result = new List<string>();
-            foreach (var token in Parsed.GetTokens())
-            {
-                result.Add(token.Symbol.Name);
-            }
-            return result;
+            return Parsed.GetTokens();
         }
 
         /// <summary>

--- a/Nt.Parser.Domain/States/DefaultState.cs
+++ b/Nt.Parser.Domain/States/DefaultState.cs
@@ -1,6 +1,8 @@
-﻿namespace Nt.Parser.States
+﻿using Nt.Parser.Symbols;
+
+namespace Nt.Parser.States
 {
-    internal class DefaultState(SymbolsParser parser) : IState
+    internal class DefaultState<T>(SymbolsParser<T> parser) : IState where T : ISymbol
     {
         public void Handle(char c)
         {
@@ -8,7 +10,7 @@
             {
                 parser.ParseCurrent();
                 parser.CurrentToken = c.ToString();
-                parser.CurrentState = new SymbolState(parser);
+                parser.CurrentState = new SymbolState<T>(parser);
             }
             else if (parser.Separators.Contains(c))
             {
@@ -16,7 +18,7 @@
             }
             else if (c == '\\')
             {
-                parser.CurrentState = new EscapeCharState(parser);
+                parser.CurrentState = new EscapeCharState<T>(parser);
             }
             else parser.CurrentToken += c;
         }

--- a/Nt.Parser.Domain/States/EscapeCharState.cs
+++ b/Nt.Parser.Domain/States/EscapeCharState.cs
@@ -1,10 +1,12 @@
-﻿namespace Nt.Parser.States
+﻿using Nt.Parser.Symbols;
+
+namespace Nt.Parser.States
 {
-    internal class EscapeCharState(SymbolsParser parser) : IState
+    internal class EscapeCharState<T>(SymbolsParser<T> parser) : IState where T : ISymbol
     {
         public void Handle(char c)
         {
-            parser.CurrentState = new DefaultState(parser);
+            parser.CurrentState = new DefaultState<T>(parser);
             parser.CurrentToken += c;
         }
     }

--- a/Nt.Parser.Domain/States/SymbolState.cs
+++ b/Nt.Parser.Domain/States/SymbolState.cs
@@ -1,6 +1,8 @@
-﻿namespace Nt.Parser.States
+﻿using Nt.Parser.Symbols;
+
+namespace Nt.Parser.States
 {
-    internal class SymbolState(SymbolsParser parser) : IState
+    internal class SymbolState<T>(SymbolsParser<T> parser) : IState where T : ISymbol
     {
 
         public void Handle(char c)
@@ -8,7 +10,7 @@
             List<char> next = parser.NextSymbols(parser.CurrentToken);
             if (c == '\\')
             {
-                parser.CurrentState = new EscapeCharState(parser);
+                parser.CurrentState = new EscapeCharState<T>(parser);
             }
             else if (next.Contains(c))
             {
@@ -22,13 +24,13 @@
             else if (parser.Separators.Contains(c))
             {
                 parser.ParseCurrent();
-                parser.CurrentState = new DefaultState(parser);
+                parser.CurrentState = new DefaultState<T>(parser);
             }
             else
             {
                 parser.ParseCurrent();
                 parser.CurrentToken = c.ToString();
-                parser.CurrentState = new DefaultState(parser);
+                parser.CurrentState = new DefaultState<T>(parser);
             }
         }
     }

--- a/Nt.Parser.Domain/Structures/ParsedList.cs
+++ b/Nt.Parser.Domain/Structures/ParsedList.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using Nt.Parser.Symbols;
+using System.Text;
 
 namespace Nt.Parser.Structures
 {
@@ -7,15 +8,15 @@ namespace Nt.Parser.Structures
     /// Represents a list of parsed words, identified by their value.
     /// </summary>
     /// <param name="symbols">List of tokens that contains all parsed tokens</param>
-    public class ParsedList
+    public class ParsedList<T> where T : ISymbol 
     {
-        private List<ParsedToken> Tokens { get; } = [];
+        private List<ParsedToken<T>> Tokens { get; } = [];
 
         /// <summary>
         /// Returns a list of all parsed tokens.
         /// </summary>
         /// <returns>A list of objects representing the parsed tokens.</returns>
-        public List<ParsedToken> GetTokens() => [.. Tokens];
+        public List<ParsedToken<T>> GetTokens() => [.. Tokens];
 
         /// <summary>
         /// Gets the total number of parsed tokens in the list.
@@ -28,16 +29,16 @@ namespace Nt.Parser.Structures
         /// </summary>
         /// <param name="index">The zero-based index of the token to retrieve.</param>
         /// <returns>The parsed token located at the specified index.</returns>
-        public ParsedToken Get(int index) => Tokens[index];
+        public ParsedToken<T> Get(int index) => Tokens[index];
 
         /// <summary>
         /// Adds a parsed token for the specified symbol at the given line number.
         /// </summary>
         /// <param name="symbol">The symbol to associate with the new parsed token.</param>
         /// <param name="line">The line number where the symbol appears. Must be greater or equal to 1, or -1 for no line.</param>
-        public void Add(Symbol symbol, int line)
+        public void Add(T symbol, int line)
         {
-            Tokens.Add(new ParsedToken(symbol, line));
+            Tokens.Add(new ParsedToken<T>(symbol, line));
         }
 
         /// <summary>

--- a/Nt.Parser.Domain/Structures/ParsedToken.cs
+++ b/Nt.Parser.Domain/Structures/ParsedToken.cs
@@ -1,16 +1,18 @@
-﻿namespace Nt.Parser.Structures
+﻿using System.Numerics;
+
+namespace Nt.Parser.Structures
 {
     /// <summary>
     /// Represents a parsed token identified by its index in list of tokens
     /// </summary>
     /// <param name="index">Index in tokens list</param>
     /// <param name="line">Line the token have been parsed</param>
-    public class ParsedToken(Symbol symbol, int line)
+    public class ParsedToken<T>(T symbol, int line)
     {
         /// <summary>
         /// Represents the symbol associated with this parsed token.
         /// </summary>
-        public Symbol Symbol { get; } = symbol;
+        public T Symbol { get; } = symbol;
         /// <summary>
         /// Line the token have been parsed
         /// </summary>

--- a/Nt.Parser.Domain/Structures/SymbolsList.cs
+++ b/Nt.Parser.Domain/Structures/SymbolsList.cs
@@ -1,25 +1,31 @@
-﻿using System.Text;
+﻿using Nt.Parser.Symbols;
+using System.Text;
 
 namespace Nt.Parser.Structures
 {
 
-    public class SymbolsList
+    public class SymbolsList<T> where T : ISymbol
     {
-        private List<Symbol> Symbols { get; } = [];
+        private List<T> Symbols { get; } = [];
+        private ISymbolFactory<T> Factory { get; }
 
         #region Constructors
 
         /// <summary>
         /// Instantiates a list of tokens
         /// </summary>
-        public SymbolsList() : base() { }
+        public SymbolsList(ISymbolFactory<T> factory) : base() 
+        {
+            Factory = factory;
+        }
         /// <summary>
         /// Instantiates a list of tokens from a list of strings.
         /// </summary>
         /// <param name="list">List of string used to instantiate the tokens</param>
-        public SymbolsList(List<string> list)
+        public SymbolsList(ISymbolFactory<T> factory, List<string> list)
         {
-            foreach (var word in list) Symbols.Add(new Symbol(word));
+            Factory = factory;
+            foreach (var word in list) Symbols.Add(factory.Create(word));
         }
 
         #endregion
@@ -31,11 +37,11 @@ namespace Nt.Parser.Structures
         /// </summary>
         /// <param name="name">Name of the token to add</param>
         /// <returns>Last index of the list once the token has been added, or index of the existing one</returns>
-        public Symbol Add(string name)
+        public T Add(string name)
         {
             if (!Contains(name))
             {
-                var symbol = new Symbol(name);
+                var symbol = Factory.Create(name);
                 Symbols.Add(symbol);
                 return symbol;
             }
@@ -49,7 +55,7 @@ namespace Nt.Parser.Structures
         /// <returns>Last index of the list once all the tokens have been added</returns>
         public int AddRange(IEnumerable<string> names)
         {
-            foreach (var name in names) Symbols.Add(new Symbol(name));
+            foreach (var name in names) Symbols.Add(Factory.Create(name));
             return Symbols.Count - 1;
         }
 
@@ -57,7 +63,7 @@ namespace Nt.Parser.Structures
         /// Returns a list of all symbols currently contained in the collection.
         /// </summary>
         /// <returns>A list of objects representing the symbols in the collection.</returns>
-        public List<Symbol> GetSymbols()
+        public List<T> GetSymbols()
         {
             return [.. Symbols];
         }
@@ -68,9 +74,9 @@ namespace Nt.Parser.Structures
         /// <param name="name">Name of the token to get</param>
         /// <returns>First occurence of such token with the given name in the list</returns>
         /// <exception cref="KeyNotFoundException">It might be that no token with the given name was found.</exception>
-        public Symbol Get(string name)
+        public T Get(string name)
         {
-            foreach (Symbol token in Symbols)
+            foreach (var token in Symbols)
             {
                 if (token.Name == name) { return token; }
             }
@@ -82,7 +88,7 @@ namespace Nt.Parser.Structures
         /// </summary>
         /// <param name="index">Index of the token</param>
         /// <returns>Symbol at the specified index</returns>
-        public Symbol Get(int index)
+        public T Get(int index)
         {
             return Symbols[index];
         }
@@ -121,7 +127,7 @@ namespace Nt.Parser.Structures
         /// <returns>True if the token is in the list, False if not</returns>
         public bool Contains(string name)
         {
-            foreach (Symbol token in Symbols)
+            foreach (var token in Symbols)
             {
                 if (token.Name.Equals(name)) { return true; }
             }

--- a/Nt.Parser.Domain/Symbols/ISymbol.cs
+++ b/Nt.Parser.Domain/Symbols/ISymbol.cs
@@ -1,0 +1,7 @@
+﻿namespace Nt.Parser.Symbols
+{
+    public interface ISymbol
+    {
+        string Name { get; }
+    }
+}

--- a/Nt.Parser.Domain/Symbols/ISymbolFactory.cs
+++ b/Nt.Parser.Domain/Symbols/ISymbolFactory.cs
@@ -1,0 +1,18 @@
+﻿namespace Nt.Parser.Symbols
+{
+    public interface ISymbolFactory<T>
+    {
+        T Create(string name);
+    }
+
+    ///// <summary>
+    ///// Represents a token. A token is just a word.
+    ///// </summary>
+    //public class Symbol(string name)
+    //{
+    //    public string Name { get; } = name;
+
+    //    public override string ToString() => Name;
+
+    //}
+}

--- a/Nt.Parser.Domain/Symbols/Symbol.cs
+++ b/Nt.Parser.Domain/Symbols/Symbol.cs
@@ -1,5 +1,6 @@
-﻿namespace Nt.Parser.Structures
+﻿namespace Nt.Parser.Symbols
 {
+
     /// <summary>
     /// Represents a token. A token is just a word.
     /// </summary>

--- a/Nt.Parser.Domain/Symbols/Symbol.cs
+++ b/Nt.Parser.Domain/Symbols/Symbol.cs
@@ -2,9 +2,9 @@
 {
 
     /// <summary>
-    /// Represents a token. A token is just a word.
+    /// Represents a symbol with a name.
     /// </summary>
-    public class Symbol(string name)
+    public class Symbol(string name) : ISymbol
     {
         public string Name { get; } = name;
 

--- a/Nt.Parser.Domain/Symbols/SymbolFactory.cs
+++ b/Nt.Parser.Domain/Symbols/SymbolFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Nt.Parser.Symbols
+{
+    /// <summary>
+    /// Provides a factory for creating instances of the <see cref="Symbol"> class.
+    /// </summary>
+    public class SymbolFactory : ISymbolFactory<Symbol>
+    {
+        public Symbol Create(string name) => new Symbol(name);
+    }
+}

--- a/Nt.Parser.Domain/SymbolsParser.cs
+++ b/Nt.Parser.Domain/SymbolsParser.cs
@@ -1,5 +1,6 @@
 ﻿using Nt.Parser.Exceptions;
 using Nt.Parser.States;
+using Nt.Parser.Symbols;
 
 namespace Nt.Parser
 {
@@ -7,18 +8,19 @@ namespace Nt.Parser
     /// <summary>
     /// Represents a parser that can be customized
     /// </summary>
-    public class SymbolsParser : IParser
+    public class SymbolsParser<T> : IParser<T> where T : ISymbol
     {
 
         #region Parameters
 
         internal string CurrentToken { get; set; } = "";
         internal int CurrentLine { get; private set; } = -1;
-        private ParserResult Result { get; set; } = new();
+        private ISymbolFactory<T> Factory { get; }
+        private ParserResult<T> Result { get; set; }
 
-        internal List<char> Separators { get; } = [' '];
+        internal List<char> Separators { get; }
         internal List<char> Breaks { get; } = [];
-        internal List<string> Symbols { get; set; } = [];
+        internal List<string> Symbols { get; set; }
 
         internal IState? CurrentState { get; set; }
 
@@ -27,20 +29,15 @@ namespace Nt.Parser
         #region Constructors
 
         /// <summary>
-        /// Represents a parser with default separators and symbols list
-        /// </summary>
-        public SymbolsParser()
-        {
-            SetSymbols();
-        }
-
-        /// <summary>
         /// Represents a parser with custom separators and symbols list
         /// </summary>
+        /// <param name="factory">Factory to create symbols</param>
         /// <param name="separators">List of words separators</param>
         /// <param name="symbols">List of symbols</param>
-        public SymbolsParser(List<char> separators, List<string> symbols)
+        public SymbolsParser(ISymbolFactory<T> factory, List<char> separators, List<string> symbols)
         {
+            Factory = factory;
+            Result = new ParserResult<T>(Factory);
             Separators = separators;
             Symbols = symbols;
             SetSymbols();
@@ -103,13 +100,13 @@ namespace Nt.Parser
         /// </summary>
         /// <param name="content">String to parse</param>
         /// <returns>Informations about the parsing stored in a parser result class</returns>
-        public ParserResult Parse(string content)
+        public ParserResult<T> Parse(string content)
         {
             // Resets all parameters
             CurrentToken = "";
             CurrentLine = 1;
-            Result = new();
-            CurrentState = new DefaultState(this);
+            Result = new(Factory);
+            CurrentState = new DefaultState<T>(this);
 
             // Parses all characters
             foreach (char c in content)

--- a/Nt.Parser.Tests/SymbolsParserTest.cs
+++ b/Nt.Parser.Tests/SymbolsParserTest.cs
@@ -147,7 +147,7 @@ namespace Nt.Tests.Parser
             Assert.Equal(expectedTokens.Count, parsed.Count);
             for (var i = 0; i < expectedTokens.Count; i++)
             {
-                Assert.Equal(expectedTokens[i], parsed[i]);
+                Assert.Equal(expectedTokens[i], parsed[i].Symbol.Name);
             }
         }
 

--- a/Nt.Parser.Tests/SymbolsParserTest.cs
+++ b/Nt.Parser.Tests/SymbolsParserTest.cs
@@ -1,5 +1,6 @@
 ﻿using Nt.Parser;
 using Nt.Parser.Exceptions;
+using Nt.Parser.Symbols;
 
 namespace Nt.Tests.Parser
 {
@@ -8,7 +9,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSeparator_Test1()
         {
-            var parser = new SymbolsParser([' '], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [' '], []);
             var stringToParse = "a b c d e";
             var expectedTokens = new List<string>(["a", "b", "c", "d", "e"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -17,7 +18,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSeparator_Test2()
         {
-            var parser = new SymbolsParser(['-'], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), ['-'], []);
             var stringToParse = "a-b--c---d----e";
             var expectedTokens = new List<string>(["a", "b", "c", "d", "e"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -26,7 +27,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSymbols_Test1()
         {
-            var parser = new SymbolsParser([' '], ["+", "-", "*", "/"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [' '], ["+", "-", "*", "/"]);
             var stringToParse = "a + b - c * d / e";
             var expectedTokens = new List<string>(["a", "+", "b", "-", "c", "*", "d", "/", "e"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -35,7 +36,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSymbols_Test2()
         {
-            var parser = new SymbolsParser([], ["+", "-", "*", "/"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], ["+", "-", "*", "/"]);
             var stringToParse = "a+b-c*d/e";
             var expectedTokens = new List<string>(["a", "+", "b", "-", "c", "*", "d", "/", "e"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -44,7 +45,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSymbols_Test3()
         {
-            var parser = new SymbolsParser([' '], ["+", "++", "+++"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [' '], ["+", "++", "+++"]);
             var stringToParse = "a+ b++ c+++";
             var expectedTokens = new List<string>(["a", "+", "b", "++", "c", "+++"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -53,7 +54,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseSymbols_Test4()
         {
-            var parser = new SymbolsParser([], ["+", "++", "+++"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], ["+", "++", "+++"]);
             var stringToParse = "a+b++c+++";
             var expectedTokens = new List<string>(["a", "+", "b", "++", "c", "+++"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -62,7 +63,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_Test1()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             var stringToParse = "\\a";
             var expectedTokens = new List<string>(["a"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -71,7 +72,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_Test2()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             var stringToParse = "a\\b";
             var expectedTokens = new List<string>(["ab"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -80,7 +81,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_Test3()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             var stringToParse = "\\ab";
             var expectedTokens = new List<string>(["ab"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -89,7 +90,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_Test4()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             var stringToParse = "a\\\\b";
             var expectedTokens = new List<string>(["a\\b"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -98,7 +99,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_TestSeparator()
         {
-            var parser = new SymbolsParser([' '], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [' '], []);
             var stringToParse = "a\\ b";
             var expectedTokens = new List<string>(["a b"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -107,7 +108,7 @@ namespace Nt.Tests.Parser
         [Fact]
         public void ParseEscape_TestSymbol()
         {
-            var parser = new SymbolsParser([], ["+"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], ["+"]);
             var stringToParse = "a\\+b";
             var expectedTokens = new List<string>(["a+b"]);
             ParseString(parser, stringToParse, expectedTokens);
@@ -116,30 +117,30 @@ namespace Nt.Tests.Parser
         [Fact]
         public void AddEmptySymbol_Test()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             Assert.Throws<EmptySymbolException>(() => parser.AddSymbol(""));
         }
         [Fact]
         public void AddExistingSymbol_Exception()
         {
-            var parser = new SymbolsParser([], ["*"]);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], ["*"]);
             Assert.Throws<RegisteredSymbolException>(() => parser.AddSymbol("*"));
         }
 
         [Fact]
         public void RemoveEmptySymbol_Test()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             Assert.Throws<EmptySymbolException>(() => parser.RemoveSymbol(""));
         }
         [Fact]
         public void RemoveNonExistingSymbol_Test()
         {
-            var parser = new SymbolsParser([], []);
+            var parser = new SymbolsParser<Symbol>(new SymbolFactory(), [], []);
             Assert.Throws<UnregisteredSymbolException>(() => parser.RemoveSymbol("/"));
         }
 
-        private static void ParseString(SymbolsParser parser, string stringToParse, List<string> expectedTokens)
+        private static void ParseString(SymbolsParser<Symbol> parser, string stringToParse, List<string> expectedTokens)
         {
             var result = parser.Parse(stringToParse);
             var parsed = result.GetParsed();

--- a/README.md
+++ b/README.md
@@ -41,18 +41,41 @@ Please note that any first character of a symbol is considered as a breaker and 
 |`>`,`-->`|`-->` -> `-->`|although `>` is a breaker symbol, `-->` is also a symbol|
 |`>`, `->`, `-->`|`-->` -> `-->`|although `->` is a symbol, the presence of `--` before `>` makes `-->` prime on `->`|
 
+This project contains a default type of symbol in `Nt.Syntax.Symbols.Symbol`. This symbol contains one field that represents the name of the symbol.
+By extending the `ISymbol` class in the same namespace, you can create your own type of symbol with custom fields and methods.
+
+This is particularly useful if you want the symbol to implement new interfaces. Here is an example of a custom symbol:
+```csharp
+/// <summary>
+/// Represent a symbol with a name and a custom field.
+/// </summary>
+public class CustomSymbol(string name, int custom) : ISymbol, ICustomInterface
+{
+    public string Name { get; } = name; // only field from ISymbol interface
+
+    public int CustomField; // You can define other fields
+    
+    public override int CustomMethod() { }; // You can also define custom methods
+}
+```
+
+The parser creates token. As the type of symbol used is unknown from the parser, you need to provide it a factory that extends `ISymbolFactory`. The default one is `Nt.Parser.Symbols.SymbolFactory` that creates instances of the default symbol `Symbol`.
+
 ## Using the parser
 You can create an instance of the `SymbolsParser`
 ```csharp
 using Nt.Parser;
-var parser = new SymbolsParser(separators, symbols);
+using Nt.Parser.Symbols;
+
+var parser = new SymbolsParser<Symbol>(new SymbolFactory(), separators, symbols);
 ```
 
+Here `Symbol` refers to the type of symbol used in the parser and `SymbolFactory` the factory to instantiate them. See [the symbols section](#symbols) for more details.
 Use the method `SetSymbols`, `AddSymbol` or `RemoveSymbol` to set the symbols after creating the parser.
 
 To parse a string, use the method `ParseString`
 ```csharp
-ParserResult parsed = parser.ParseString(inputString);
+ParserResult<Symbol> parsed = parser.ParseString(inputString);
 ```
 
 A `ParserResult` is a structure that contains


### PR DESCRIPTION
The symbol used by the parser must implement `ISymbol` interface. All types of symbols must have a corresponding factory.

A default implementation `Symbol` and its factore `SymbolFactory` is given, with possibility to create new symbols.

 See documentation for more details.